### PR TITLE
Feature add pre-commit tool to workflow

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+---
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+      - id: check-yaml
+      - id: check-added-large-files
+        args: [--maxkb=4096]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.3
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format


### PR DESCRIPTION
### Summary
This adds a config file for [pre-commit](https://pre-commit.com). This tool is a framework to install git-hooks which serve the purpose of running code/programs on certain git events like pre-commit and pre-merge-commit and more.

### How to use
- Install pre-commit
```
pipx install pre-commit
```
- Install hooks inside repo
```
pre-commit install
```
- work normally and commit
something like this should run before the commit

![wezterm-gui_OKTJd8JsgO](https://github.com/BotBlake/pyTAB/assets/115424318/031d61d5-55e9-4497-b09b-4e705ec6973b)

### Details
I added common hooks from the pre-commit sample-config and ruff-pre-commit hooks to run ruff formater and ruff lint --fix. Some of the problems are easy enough to be autofixable. but if one of the hooks return a non 0 value then the commit won't happen.

#### trailing-whitespace
This rule removes the white space in the last character of a row.

#### end-of-file-fixer
This rule checks if the files end on a new line.

#### check-yaml
 Check if yaml files are syntax correct. 

#### check-added-large-files
Prevents giant files to be commited. By default this has 500kB, I set the config at 4096kB via args: [--maxkb=]

#### ruff
Runs ruff --format and ruff  --fix. 