### PR TITLE
Feature/globalprogress

### DIFF
--- a/pytab/core.py
+++ b/pytab/core.py
@@ -439,7 +439,7 @@ def cli(
                 for command in commands:
                     if command["type"] in supported_types:
                         test_arg_count += 1
-    click.echo(f"We will do {test_arg_count} tests.")
+        click.echo(f"We will do {test_arg_count} tests.")
 
     if not click.confirm("Do you want to continue?"):
         click.echo("Exiting...")

--- a/pytab/core.py
+++ b/pytab/core.py
@@ -150,15 +150,14 @@ def benchmark(ffmpeg_cmd: str, debug_flag: bool, prog_bar) -> tuple:
     runs = []
     total_workers = 1
     run = True
-    last_Speed = -0.5  # to Assure first worker always has the required difference
+    last_speed = -0.5  # to Assure first worker always has the required difference
+    formatted_last_speed = "00.00"
     failure_reason = []
     if debug_flag:
-        click.echo(f"> > > > Workers: {total_workers}, Last Speed: 0")
+        click.echo(f"> > > > Workers: {total_workers}, Last Speed: {last_speed}")
     while run:
         if not debug_flag:
-            prog_bar.label = (
-                f"Testing | Workers: {total_workers} | Last Speed: {last_Speed}"
-            )
+            prog_bar.label = f"Testing | Workers: {total_workers:02d} | Last Speed: {formatted_last_speed}"
             prog_bar.render_progress()
         output = worker.workMan(total_workers, ffmpeg_cmd)
         # First check if we continue Running:
@@ -168,16 +167,17 @@ def benchmark(ffmpeg_cmd: str, debug_flag: bool, prog_bar) -> tuple:
         elif output[1]["speed"] < 1:
             run = False
             failure_reason.append("performance")
-        # elif output[1]["speed"]-last_Speed < 0.5:
+        # elif output[1]["speed"]-last_speed < 0.5:
         #    run = False
         #    failure_reason.append("failed_inconclusive")
         else:  # When no failure happened
             runs.append(output[1])
             total_workers += 1
-            last_Speed = output[1]["speed"]
+            last_speed = output[1]["speed"]
+            formatted_last_speed = f"{last_speed:05.2f}"
             if debug_flag:
                 click.echo(
-                    f"> > > > Workers: {total_workers}, Last Speed: {last_Speed}"
+                    f"> > > > Workers: {total_workers}, Last Speed: {last_speed}"
                 )
     if debug_flag:
         click.echo(f"> > > > Failed: {failure_reason}")
@@ -190,11 +190,11 @@ def benchmark(ffmpeg_cmd: str, debug_flag: bool, prog_bar) -> tuple:
             "single_worker_rss_kb": runs[(len(runs)) - 1]["rss_kb"],
         }
         prog_bar.label = (
-            f"Test done | Workers: {max_streams} | Failure: {failure_reason[0]}"
+            f"Done    | Workers: {max_streams} | Last Speed: {formatted_last_speed}"
         )
         return True, runs, result
     else:
-        prog_bar.label = "Test skipped | Workers: 0 |"
+        prog_bar.label = "Skipped | Workers: 00 | Last Speed: 00.00"
         return False, runs, {}
 
 

--- a/pytab/core.py
+++ b/pytab/core.py
@@ -429,10 +429,6 @@ def cli(
     click.echo(click.style("Done", fg="green"))
     click.echo()
 
-    if not click.confirm("Do you want to continue?"):
-        click.echo("Exiting...")
-        exit()
-
     # Count ammount of tests required to do:
     test_arg_count = 0
     if not debug_flag:
@@ -444,6 +440,10 @@ def cli(
                     if command["type"] in supported_types:
                         test_arg_count += 1
     click.echo(f"We will do {test_arg_count} tests.")
+
+    if not click.confirm("Do you want to continue?"):
+        click.echo("Exiting...")
+        exit()
 
     benchmark_data = []
     click.echo()

--- a/pytab/core.py
+++ b/pytab/core.py
@@ -152,29 +152,26 @@ def benchmark(ffmpeg_cmd: str) -> tuple:
     run = True
     last_Speed = -0.5  # to Assure first worker always has the required difference
     failure_reason = []
+    click.echo(f"> > > > Workers: {total_workers}, Last Speed: 0")
 
-    with click.progressbar(
-        length=0, label=f"Workers: {total_workers}, Speed: 0.0"
-    ) as progress_bar:
-        while run:
-            output = worker.workMan(total_workers, ffmpeg_cmd)
-            # First check if we continue Running:
-            if output[0]:
-                run = False
-                failure_reason.append(output[1])
-            elif output[1]["speed"] < 1:
-                run = False
-                failure_reason.append("performance")
-            # elif output[1]["speed"]-last_Speed < 0.5:
-            #    run = False
-            #    failure_reason.append("failed_inconclusive")
-            else:  # When no failure happened
-                runs.append(output[1])
-                total_workers += 1
-                last_Speed = output[1]["speed"]
-                progress_bar.label = f"Workers: {total_workers}, Speed: {last_Speed}"
-            progress_bar.update(1)
-        progress_bar.update(1)
+    while run:
+        output = worker.workMan(total_workers, ffmpeg_cmd)
+        # First check if we continue Running:
+        if output[0]:
+            run = False
+            failure_reason.append(output[1])
+        elif output[1]["speed"] < 1:
+            run = False
+            failure_reason.append("performance")
+        # elif output[1]["speed"]-last_Speed < 0.5:
+        #    run = False
+        #    failure_reason.append("failed_inconclusive")
+        else:  # When no failure happened
+            runs.append(output[1])
+            total_workers += 1
+            last_Speed = output[1]["speed"]
+            click.echo(f"> > > > Workers: {total_workers}, Last Speed: {last_Speed}")
+
     if len(runs) > 0:
         result = {
             "max_streams": runs[(len(runs)) - 1]["workers"],
@@ -425,7 +422,7 @@ def cli(
     benchmark_data = []
     click.echo("Starting Benchmark...")
     for file in files:  # File Benchmarking Loop
-        click.echo(f"> Current File: {file['name']}")
+        click.echo(f"| Current File: {file['name']}")
         filename = os.path.basename(file["source_url"])
         current_file = f"{video_path}/{filename}"
         tests = file["data"]

--- a/pytab/core.py
+++ b/pytab/core.py
@@ -146,13 +146,14 @@ def unpackArchive(archive_path, target_path):
     click.echo(" success!")
 
 
-def benchmark(ffmpeg_cmd: str) -> tuple:
+def benchmark(ffmpeg_cmd: str, debug_flag: bool) -> tuple:
     runs = []
     total_workers = 1
     run = True
     last_Speed = -0.5  # to Assure first worker always has the required difference
     failure_reason = []
-    click.echo(f"> > > > Workers: {total_workers}, Last Speed: 0")
+    if debug_flag:
+        click.echo(f"> > > > Workers: {total_workers}, Last Speed: 0")
 
     while run:
         output = worker.workMan(total_workers, ffmpeg_cmd)
@@ -170,8 +171,12 @@ def benchmark(ffmpeg_cmd: str) -> tuple:
             runs.append(output[1])
             total_workers += 1
             last_Speed = output[1]["speed"]
-            click.echo(f"> > > > Workers: {total_workers}, Last Speed: {last_Speed}")
-
+            if debug_flag:
+                click.echo(
+                    f"> > > > Workers: {total_workers}, Last Speed: {last_Speed}"
+                )
+    if debug_flag:
+        click.echo(f"> > > > Failed: {failure_reason}")
     if len(runs) > 0:
         result = {
             "max_streams": runs[(len(runs)) - 1]["workers"],
@@ -422,19 +427,22 @@ def cli(
     benchmark_data = []
     click.echo("Starting Benchmark...")
     for file in files:  # File Benchmarking Loop
-        click.echo(f"| Current File: {file['name']}")
+        if debug_flag:
+            click.echo(f"| Current File: {file['name']}")
         filename = os.path.basename(file["source_url"])
         current_file = f"{video_path}/{filename}"
         tests = file["data"]
         for test in tests:
-            click.echo(
-                f"> > Current Test: {test['from_resolution']} - {test['to_resolution']}"
-            )
+            if debug_flag:
+                click.echo(
+                    f"> > Current Test: {test['from_resolution']} - {test['to_resolution']}"
+                )
             commands = test["arguments"]
             for command in commands:
                 test_data = {}
                 if command["type"] in supported_types:
-                    click.echo(f"> > > Current Device: {command['type']}")
+                    if debug_flag:
+                        click.echo(f"> > > Current Device: {command['type']}")
                     arguments = command["args"]
                     arguments = arguments.format(video_file=current_file, gpu=gpu_idx)
                     test_cmd = f"{ffmpeg_binary} {arguments}"


### PR DESCRIPTION
Added a Global Progress bar, that hides all the detailed output.

Detailed output can be accessed through the `--debug` flag.
This bar is only showing Information about the current test that is being run and updates every worker-addition / rerun.

It works by counting how many `args` (commands) need to be tested in total and then counting how many where already done.
Therefore Progress is shown realy reliable, while the "time remaining" calculation is absolutely off.