### PR TITLE
Fix bug with dynamic Worker addition and NvEnc Limit

### DIFF
--- a/pytab/core.py
+++ b/pytab/core.py
@@ -165,7 +165,7 @@ def benchmark(ffmpeg_cmd: str, debug_flag: bool, prog_bar) -> tuple:
         if output[0] and total_workers == 1:
             run = False
             failure_reason.append(output[1])
-        # Scaleback when fail on 1<workers (NvEnc Limit) or on Speed<1 with 1<last added workers or on last_Speed = Scaleback
+        # When run after scaleback succeded:
         elif (last_speed < 1 and not output[0]) and last_speed != -0.5:
             limited = False
             if last_speed == -1:
@@ -177,11 +177,12 @@ def benchmark(ffmpeg_cmd: str, debug_flag: bool, prog_bar) -> tuple:
                     f"> > > > Scaleback success! Limit: {limited}, Total Workers: {total_workers}, Speed: {last_speed}"
                 )
             run = False
-            failure_reason.append("performance")
+
             if limited:
                 failure_reason.append("limited")
-
-            failure_reason.append("")
+            else:
+                failure_reason.append("performance")
+        # Scaleback when fail on 1<workers (NvEnc Limit) or on Speed<1 with 1<last added workers or on last_Speed = Scaleback
         elif (
             (total_workers > 1 and output[0])
             or (output[1]["speed"] < 1 and last_speed >= 2)

--- a/pytab/core.py
+++ b/pytab/core.py
@@ -166,6 +166,22 @@ def benchmark(ffmpeg_cmd: str, debug_flag: bool, prog_bar) -> tuple:
             run = False
             failure_reason.append(output[1])
         # Scaleback when fail on 1<workers (NvEnc Limit) or on Speed<1 with 1<last added workers or on last_Speed = Scaleback
+        elif last_speed < 1 and not output[0]:
+            limited = False
+            if last_speed == -1:
+                limited = True
+            last_speed = output[1]["speed"]
+            formatted_last_speed = f"{last_speed:05.2f}"
+            if debug_flag:
+                click.echo(
+                    f"> > > > Scaleback success! Limit: {limited}, Total Workers: {total_workers}, Speed: {last_speed}"
+                )
+            run = False
+            failure_reason.append("performance")
+            if limited:
+                failure_reason.append("limited")
+
+            failure_reason.append("")
         elif (
             (total_workers > 1 and output[0])
             or (output[1]["speed"] < 1 and last_speed >= 2)

--- a/pytab/core.py
+++ b/pytab/core.py
@@ -161,18 +161,31 @@ def benchmark(ffmpeg_cmd: str, debug_flag: bool, prog_bar) -> tuple:
             prog_bar.render_progress()
         output = worker.workMan(total_workers, ffmpeg_cmd)
         # First check if we continue Running:
-        if output[0]:
+        # Stop when first run failed
+        if output[0] and total_workers == 1:
             run = False
             failure_reason.append(output[1])
-        elif output[1]["speed"] < 1 and last_speed > 2:
-            # last run was a jump of more then 1 so scale back for as long as you dont find a just right number of processors
-            last_speed = output[1]["speed"]
+        # Scaleback when fail on 1<workers (NvEnc Limit) or on Speed<1 with 1<last added workers or on last_Speed = Scaleback
+        elif (
+            (total_workers > 1 and output[0])
+            or (output[1]["speed"] < 1 and last_speed >= 2)
+            or (last_speed == -1)
+        ):
+            if output[0]:  # Assign variables depending on Scaleback reason
+                last_speed = -1
+                formatted_last_speed = "sclbk"
+            else:
+                last_speed = output[1]["speed"]
+                formatted_last_speed = f"{last_speed:05.2f}"
             total_workers -= 1
-            formatted_last_speed = f"{last_speed:05.2f}"
             if debug_flag:
                 click.echo(
                     f"> > > > Scaling back to: {total_workers}, Last Speed: {last_speed}"
                 )
+        elif output[0] and total_workers == 0:  # Fail when infinite scaleback
+            run = False
+            failure_reason.append(output[1])
+            failure_reason.append("infinity_scaleback")
         elif output[1]["speed"] < 1:
             run = False
             failure_reason.append("performance")

--- a/pytab/core.py
+++ b/pytab/core.py
@@ -166,7 +166,7 @@ def benchmark(ffmpeg_cmd: str, debug_flag: bool, prog_bar) -> tuple:
             run = False
             failure_reason.append(output[1])
         # Scaleback when fail on 1<workers (NvEnc Limit) or on Speed<1 with 1<last added workers or on last_Speed = Scaleback
-        elif last_speed < 1 and not output[0]:
+        elif (last_speed < 1 and not output[0]) and last_speed != -0.5:
             limited = False
             if last_speed == -1:
                 limited = True


### PR DESCRIPTION
This patches the "end run" feature, so that it is abled to scale down Worker Ammount properly.

Before this, any ffmpeg process failure lead to termination of the run and further testing with this command.
Since NvEnc Limited runs also FAIL, the script needs to downscale until there was a run that did not fail.

The current Worker upscaling logic made this issue possible by scaling up like so:

| Worker ammount   |   Speed |
|---------------------|---------|
|1          |  16.1234   |
|16| ERROR (NvEnc Limit)||

_And marking the run as done._
`Max Workers: 1, Speed: 16.1234`

---
The modifications of this patch allow the Script to scale down the Worker ammount until no Error happened.
The same test would now look like this:
| Worker ammount   |   Speed |
|---------------------|---------|
|1          |  16.1234   |
|16| ERROR (NvEnc Limit)|
|15| ERROR (NvEnc Limit)|
|14| ERROR (NvEnc Limit)|
|13| ERROR (NvEnc Limit)|
|12| ERROR (NvEnc Limit)|
|11| ERROR (NvEnc Limit)|
|10| ERROR (NvEnc Limit)|
|9| ERROR (NvEnc Limit)|
|8| 10,5432|

_And marking the run as done._
`Max Workers: 8, Speed: 10.5432`


Additionaly this patch appends the failure reason `limited`, in the case that a downscaled run after a run with an ffmpeg "Process Error" works again.

So the run above would be marked as `limited`
---

This leaves Potential for a heavier downscaling options, but these are not included into this PR