### PR TITLE
Add GPU-Vendor Check on Windows

### DIFF
--- a/pytab/hwi.py
+++ b/pytab/hwi.py
@@ -116,7 +116,7 @@ def get_gpu_info() -> list:
                 "class": "display",
                 "description": gpu.creationClassName.strip(),
                 "product": gpu.Name,
-                "vendor": vendor,
+                "vendor": check_ven(vendor),
                 "physid": gpu.DeviceID.strip(),
                 "businfo": gpu.PNPDeviceID.strip(),
                 "configuration": configuration,


### PR DESCRIPTION
Fixed a bug where the GPU wouldn't be recognized properly and no test would be run on it.