### PR TITLE
NvEnc limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,3 @@ _During development jellybench_py may require you to set up specific things manu
 ## Current Issues
 You will find a List of currently known issues below.
 These will change over time, so please ensure you check this section regularly for any changes.
-
-### NvEnc Driver Limitations
-NVIDIA imposes a limit on the maximum number of NvEnc streams for consumer-grade GPUs through the driver. This limitation currently leads to significantly increased runtimes on affected devices.  
-> [!CAUTION]  
-> If you are using an NVIDIA consumer-grade GPU and have not implemented a workaround for this limitation, it is recommended to avoid testing on such devices. Runtimes will be significantly extended!

--- a/jellybench_py/api.py
+++ b/jellybench_py/api.py
@@ -103,7 +103,7 @@ def getTestData(platformID: str, platforms_data: list, server_url: str) -> tuple
 def upload(server_url: str, data: dict):
     api_url = f"{server_url}/api/v1/SubmissionApi"
     print(f"| Uploading to {server_url}... ", end="")
-    
+
     headers = {"accept": "text/plain", "Content-Type": "application/json"}
 
     response = requests.post(api_url, json=data, headers=headers)
@@ -120,7 +120,7 @@ def upload(server_url: str, data: dict):
     print(f"Reason: {response.reason}")
     print(f"Headers: {dumps(dict(response.headers), indent=4)}")
     print(f"Elapsed Time: {response.elapsed}")
-    
+
     # Display the raw response content
     print("\n--- Raw Response Content ---")
     print(response.content)

--- a/jellybench_py/constant.py
+++ b/jellybench_py/constant.py
@@ -3,11 +3,22 @@ from enum import Enum
 
 
 @dataclass
+class CommandConfig:
+    BASE_CMD: str
+    WORKER_CMD: str
+
+
 class Constants:
     DEFAULT_OUTPUT_JSON: str = "./output.json"
     DEFAULT_SERVER_URL: str = "https://hwa.jellyfin.org"
-    NVENC_TEST_CMD_BASE: str = "{ffmpeg} -y -hwaccel cuda -hwaccel_output_format cuda -t 50 -hwaccel_device {gpu} -f lavfi -i testsrc "
-    NVENC_TEST_CMD_WORK: str = "-vf hwupload -fps_mode passthrough -c:a copy -c:v h264_nvenc -b:v {bitrate} -f null -"
+    NVENC_TEST_WINDOWS = CommandConfig(
+        BASE_CMD="{ffmpeg} -y -hwaccel cuda -hwaccel_output_format cuda -t 50 -hwaccel_device {gpu} -f lavfi -i testsrc ",
+        WORKER_CMD="-vf hwupload -fps_mode passthrough -c:a copy -c:v h264_nvenc -b:v {bitrate} -f null -",
+    )
+    NVENC_TEST_LINUX = CommandConfig(
+        BASE_CMD="{ffmpeg} -y -vsync 0 -hwaccel cuda -hwaccel_output_format cuda  -t 50 -hwaccel_device {gpu} -f lavfi -i testsrc ",
+        WORKER_CMD="-vf hwupload -c:a copy -c:v h264_nvenc -b:v {bitrate} -f null -",
+    )
 
 
 class Style(Enum):

--- a/jellybench_py/constant.py
+++ b/jellybench_py/constant.py
@@ -6,6 +6,8 @@ from enum import Enum
 class Constants:
     DEFAULT_OUTPUT_JSON: str = "./output.json"
     DEFAULT_SERVER_URL: str = "https://hwa.jellyfin.org"
+    NVENC_TEST_CMD_BASE: str = "{ffmpeg} -y -hwaccel cuda -hwaccel_output_format cuda -t 50 -hwaccel_device {gpu} -f lavfi -i testsrc "
+    NVENC_TEST_CMD_WORK: str = "-vf hwupload -fps_mode passthrough -c:a copy -c:v h264_nvenc -b:v {bitrate} -f null -"
 
 
 class Style(Enum):

--- a/jellybench_py/core.py
+++ b/jellybench_py/core.py
@@ -260,10 +260,16 @@ def benchmark(ffmpeg_cmd: str, debug_flag: bool, prog_bar) -> tuple:
 
 def check_driver_limit(device: dict, ffmpeg_binary: str, gpu_idx: int):
     def build_test_cmd(worker_ammount: int, ffmpeg_binary: str, gpu_arg) -> str:
-        base_cmd = Constants.NVENC_TEST_WINDOWS.BASE_CMD.format(
-            ffmpeg=ffmpeg_binary, gpu=gpu_arg
-        )
-        worker_base = Constants.NVENC_TEST_WINDOWS.WORKER_CMD
+        if hwi.platform.system == "windows":
+            base_cmd = Constants.NVENC_TEST_WINDOWS.BASE_CMD.format(
+                ffmpeg=ffmpeg_binary, gpu=gpu_arg
+            )
+            worker_base = Constants.NVENC_TEST_WINDOWS.WORKER_CMD
+        else:
+            base_cmd = Constants.NVENC_TEST_LINUX.BASE_CMD.format(
+                ffmpeg=ffmpeg_binary, gpu=gpu_arg
+            )
+            worker_base = Constants.NVENC_TEST_LINUX.WORKER_CMD
         worker_commands = []
         for i in range(1, worker_ammount + 1):
             bitrate = f"{i}M"

--- a/jellybench_py/core.py
+++ b/jellybench_py/core.py
@@ -260,6 +260,7 @@ def benchmark(ffmpeg_cmd: str, debug_flag: bool, prog_bar) -> tuple:
 
 def check_driver_limit(device: dict, ffmpeg_binary: str, gpu_idx: int):
     def build_test_cmd(worker_ammount: int, ffmpeg_binary: str, gpu_arg) -> str:
+        # Build an ffmpeg command to test {n}-concurrent NvEnc Streams
         if hwi.platform.system().lower() == "windows":
             base_cmd = Constants.NVENC_TEST_WINDOWS.BASE_CMD.format(
                 ffmpeg=ffmpeg_binary, gpu=gpu_arg
@@ -279,6 +280,7 @@ def check_driver_limit(device: dict, ffmpeg_binary: str, gpu_idx: int):
         return full_command
 
     def parse_driver(driver_raw: str) -> int:
+        # parse windows specific driver output into NVIDIA Version (e.g. 32.0.15.6603 --> 566.03)
         split_driver = driver_raw.split(".")
         if len(split_driver) != 4:
             return -1

--- a/jellybench_py/core.py
+++ b/jellybench_py/core.py
@@ -180,7 +180,7 @@ def benchmark(ffmpeg_cmd: str, debug_flag: bool, prog_bar, limit=0) -> tuple:
     if debug_flag:
         print(f"> > > > Workers: {total_workers}, Last Speed: {last_speed}")
     while run:
-        if total_workers > limit:
+        if limit != 0 and total_workers > limit:
             total_workers = limit
             external_limited = True
             if debug_flag:

--- a/jellybench_py/core.py
+++ b/jellybench_py/core.py
@@ -577,6 +577,9 @@ def cli() -> None:
         # print("/")
     elif len(gpus) == 1 and args.gpu_input is None:
         args.gpu_input = 1
+    elif len(gpus) == 0:
+        args.gpu_input = 0
+
     gpu = None
     gpu_idx = int(args.gpu_input) - 1
 

--- a/jellybench_py/core.py
+++ b/jellybench_py/core.py
@@ -260,7 +260,7 @@ def benchmark(ffmpeg_cmd: str, debug_flag: bool, prog_bar) -> tuple:
 
 def check_driver_limit(device: dict, ffmpeg_binary: str, gpu_idx: int):
     def build_test_cmd(worker_ammount: int, ffmpeg_binary: str, gpu_arg) -> str:
-        if hwi.platform.system == "windows":
+        if hwi.platform.system().lower() == "windows":
             base_cmd = Constants.NVENC_TEST_WINDOWS.BASE_CMD.format(
                 ffmpeg=ffmpeg_binary, gpu=gpu_arg
             )
@@ -315,7 +315,7 @@ def check_driver_limit(device: dict, ffmpeg_binary: str, gpu_idx: int):
 
     skip_device = False
     limited_driver = False
-    successfull_count = worker.test_command(command)
+    successfull_count, failure_reason = worker.test_command(command)
     if successfull_count == worker_ammount:
         print(" success!")
 
@@ -334,6 +334,7 @@ def check_driver_limit(device: dict, ffmpeg_binary: str, gpu_idx: int):
     else:
         print(" Error!")
         print("| > Your GPU is not capable of running NvEnc Streams!")
+        print(f"| > FFmpeg: {failure_reason}")
         print("| > Please run the tool again and disable GPU tests")
         exit()
     print(styled("Done", [Style.GREEN]))

--- a/jellybench_py/core.py
+++ b/jellybench_py/core.py
@@ -349,9 +349,6 @@ def check_driver_limit(device: dict, ffmpeg_binary: str, gpu_idx: int):
         print(
             f"| > Your GPU driver does only allow {successful_count} concurrent NvEnc sessions!"
         )
-        print(
-            "| > Caution: Running benchmarks on a device with driver limitations will considerably increase the runtime!"
-        )
         skip_device = confirm(
             message="| > Do you want to skip GPU tests?", default=True
         )

--- a/jellybench_py/core.py
+++ b/jellybench_py/core.py
@@ -328,7 +328,7 @@ def check_driver_limit(device: dict, ffmpeg_binary: str, gpu_idx: int):
             "| > Caution: Running benchmarks on a device with driver limitations will considerably increase the runtime!"
         )
         skip_device = confirm(
-            message="| > Do you want to skip GPU tests?: ", default=True
+            message="| > Do you want to skip GPU tests?", default=True
         )
         limited_driver = True
     else:

--- a/jellybench_py/core.py
+++ b/jellybench_py/core.py
@@ -280,10 +280,14 @@ def check_driver_limit(device: dict, ffmpeg_binary: str, gpu_idx: int):
 
     def parse_driver(driver_raw: str) -> int:
         split_driver = driver_raw.split(".")
-        if len(split_driver) < 4:
+        if len(split_driver) != 4:
             return -1
 
-        major_version = list(split_driver[-2])[-1]
+        major_version = list(split_driver[-2])
+        if 0 < len(major_version):
+            major_version = major_version[-1]
+        else:
+            return -1
         minor_version = split_driver[-1]
 
         if not (major_version.isdigit() and minor_version.isdigit()):

--- a/jellybench_py/core.py
+++ b/jellybench_py/core.py
@@ -569,6 +569,7 @@ def cli() -> None:
                     + "entering its index number into the prompt."
                 )
             args.gpu_input = input("Select GPU (0 to disable GPU tests): ")
+        args.gpu_input = int(args.gpu_input)
         # print("   _")
         # print("  /")
         # print(" /")

--- a/jellybench_py/core.py
+++ b/jellybench_py/core.py
@@ -315,14 +315,14 @@ def check_driver_limit(device: dict, ffmpeg_binary: str, gpu_idx: int):
 
     skip_device = False
     limited_driver = False
-    successfull_count, failure_reason = worker.test_command(command)
-    if successfull_count == worker_ammount:
+    successful_count, failure_reason = worker.test_command(command)
+    if successful_count == worker_ammount:
         print(" success!")
 
-    elif 0 < successfull_count < worker_ammount:
+    elif 0 < successful_count < worker_ammount:
         print(styled(" limited!", [Style.BG_RED]))
         print(
-            f"| > Your GPU driver does only allow {successfull_count} concurrent NvEnc sessions!"
+            f"| > Your GPU driver does only allow {successful_count} concurrent NvEnc sessions!"
         )
         print(
             "| > Caution: Running benchmarks on a device with driver limitations will considerably increase the runtime!"

--- a/jellybench_py/core.py
+++ b/jellybench_py/core.py
@@ -575,6 +575,8 @@ def cli() -> None:
         # print("  /")
         # print(" /")
         # print("/")
+    elif len(gpus) == 1 and args.gpu_input is None:
+        args.gpu_input = 1
     gpu = None
     gpu_idx = int(args.gpu_input) - 1
 

--- a/jellybench_py/core.py
+++ b/jellybench_py/core.py
@@ -260,10 +260,10 @@ def benchmark(ffmpeg_cmd: str, debug_flag: bool, prog_bar) -> tuple:
 
 def check_driver_limit(device: dict, ffmpeg_binary: str, gpu_idx: int):
     def build_test_cmd(worker_ammount: int, ffmpeg_binary: str, gpu_arg) -> str:
-        base_cmd = Constants.NVENC_TEST_CMD_BASE.format(
+        base_cmd = Constants.NVENC_TEST_WINDOWS.BASE_CMD.format(
             ffmpeg=ffmpeg_binary, gpu=gpu_arg
         )
-        worker_base = Constants.NVENC_TEST_CMD_WORK
+        worker_base = Constants.NVENC_TEST_WINDOWS.WORKER_CMD
         worker_commands = []
         for i in range(1, worker_ammount + 1):
             bitrate = f"{i}M"

--- a/jellybench_py/core.py
+++ b/jellybench_py/core.py
@@ -174,16 +174,19 @@ def benchmark(ffmpeg_cmd: str, debug_flag: bool, prog_bar, limit=0) -> tuple:
     last_speed = -0.5  # to Assure first worker always has the required difference
     formatted_last_speed = "00.00"
     failure_reason = []
-    external_limited = False # Flag to save if run is being limited by external factors (eg. driver)
+    external_limited = (
+        False  # Flag to save if run is being limited by external factors (eg. driver)
+    )
     if debug_flag:
         print(f"> > > > Workers: {total_workers}, Last Speed: {last_speed}")
     while run:
-        
         if total_workers > limit:
             total_workers = limit
             external_limited = True
             if debug_flag:
-                print(f"> > > > External limit hit, reducing workers to {total_workers}")
+                print(
+                    f"> > > > External limit hit, reducing workers to {total_workers}"
+                )
 
         if not debug_flag:
             prog_bar.update(
@@ -249,17 +252,16 @@ def benchmark(ffmpeg_cmd: str, debug_flag: bool, prog_bar, limit=0) -> tuple:
             formatted_last_speed = f"{last_speed:05.2f}"
             if debug_flag:
                 print(f"> > > > Workers: {total_workers}, Last Speed: {last_speed}")
-            
+
             # external limit hit
             if external_limited:
                 if debug_flag:
-                    print(f"> > > > > External limit hit, ending run")
+                    print("> > > > > External limit hit, ending run")
 
                 failure_reason.append("limited")
                 last_speed = output[1]["speed"]
                 formatted_last_speed = f"{last_speed:05.2f}"
                 run = False
-
 
     if debug_flag:
         print(f"> > > > Failed: {failure_reason}")

--- a/jellybench_py/util.py
+++ b/jellybench_py/util.py
@@ -19,3 +19,13 @@ def confirm(message: str = "Continue", default: bool | None = None) -> bool:
         print("Error: invalid input")
 
     return valid_inputs[response]
+
+def get_nvenc_session_limit(driver_version: int) -> int:
+    if driver_version >= 550.0:
+        return 8
+    elif 530.0 <= driver_version < 550.0:
+        return 5
+    elif driver_version <= 530.0:
+        return 3
+    else:
+        return 0

--- a/jellybench_py/util.py
+++ b/jellybench_py/util.py
@@ -20,6 +20,7 @@ def confirm(message: str = "Continue", default: bool | None = None) -> bool:
 
     return valid_inputs[response]
 
+
 def get_nvenc_session_limit(driver_version: int) -> int:
     if driver_version >= 550.0:
         return 8

--- a/jellybench_py/worker.py
+++ b/jellybench_py/worker.py
@@ -191,10 +191,9 @@ def test_command(ffmpeg_cmd):
 
     failure_reason = raw_worker_data[1]
     process_output = raw_worker_data[0]
-
-    if failure_reason == "incompatible client key":
+    if failure_reason == "incompatible client key" or failure_reason is None:
         success_pattern = r"Output #\d+, null, to 'pipe:'"
         successful_streams = re.findall(success_pattern, process_output)
         successful_stream_count = len(successful_streams)
-    
-    return successful_stream_count
+
+    return successful_stream_count, failure_reason

--- a/jellybench_py/worker.py
+++ b/jellybench_py/worker.py
@@ -182,3 +182,9 @@ def evaluateRunData(run_data_raw: list) -> dict:
         "avgFPS": avgFPS,
     }
     return run_data_eval
+
+
+def test_command(ffmpeg_cmd):
+    ffmpeg_cmd_list = shlex.split(ffmpeg_cmd)
+    raw_worker_data = run_ffmpeg(1, ffmpeg_cmd_list)
+    return raw_worker_data

--- a/jellybench_py/worker.py
+++ b/jellybench_py/worker.py
@@ -191,7 +191,8 @@ def test_command(ffmpeg_cmd):
 
     failure_reason = raw_worker_data[1]
     process_output = raw_worker_data[0]
-    if failure_reason == "incompatible client key" or failure_reason is None:
+    nvenc_limit_reasons = ["incompatible client key", "out of memory"]
+    if failure_reason in nvenc_limit_reasons or failure_reason is None:
         success_pattern = r"Output #\d+, null, to 'pipe:'"
         successful_streams = re.findall(success_pattern, process_output)
         successful_stream_count = len(successful_streams)

--- a/jellybench_py/worker.py
+++ b/jellybench_py/worker.py
@@ -186,5 +186,15 @@ def evaluateRunData(run_data_raw: list) -> dict:
 
 def test_command(ffmpeg_cmd):
     ffmpeg_cmd_list = shlex.split(ffmpeg_cmd)
+    successful_stream_count = 0
     raw_worker_data = run_ffmpeg(1, ffmpeg_cmd_list)
-    return raw_worker_data
+
+    failure_reason = raw_worker_data[1]
+    process_output = raw_worker_data[0]
+
+    if failure_reason == "incompatible client key":
+        success_pattern = r"Output #\d+, null, to 'pipe:'"
+        successful_streams = re.findall(success_pattern, process_output)
+        successful_stream_count = len(successful_streams)
+    
+    return successful_stream_count


### PR DESCRIPTION
## Implementation
The User Interface has been updated to allow displaying and handling NVIDIA NvEnc Session limits.
In case an Nvidia Card has been selected, the new logic will automatically get triggered.
There are two states the new UI can show:
1. Driver Limited
![grafik](https://github.com/user-attachments/assets/9fde57d1-f8a8-4b6b-8966-fd1dce7a0a32)

2. Not Limited
![grafik](https://github.com/user-attachments/assets/92474458-ed55-4ce1-bbaf-75b32c797dde)



## Technical Details
### Platform-Specific Commands
The constants.py file has been updated to include platform-specific definitions for nvenc_test_commands. This ensures that the implementation works seamlessly across different operating environments, with Windows being the initial focus.

### Driver Limit Detection
Optional functionality has been added to detect the theoretical session limit from the NVIDIA driver. This acts as a preliminary assessment before proceeding with the practical tests.

### Constructing FFmpeg Commands
The FFmpeg command dynamically adapts to test configurations by constructing a command to encode driver_limit + 1 streams. This ensures a thorough and reliable testing process, capable of detecting actual session limits.

### Parsing Test Results
The worker.py module implements logic to parse FFmpeg output, identifying the number of successfully encoded streams. This output is compared with the theoretical limit to validate the results.

## Additional
This PR includes several improvements to GPU selection, addressing issues such as:
- Correcting parsing to int in interactive GPU selection.
- set a default GPU when only one is available.
- Disable GPU-related tests when no GPU is detected.