### PR TITLE
Add flag to ignore file hashes

### DIFF
--- a/jellybench_py/core.py
+++ b/jellybench_py/core.py
@@ -120,7 +120,7 @@ def obtainSource(
         if args.ignore_hash:
             print_debug("> Server Provided Hashes:")
             for idx, item in enumerate(hash_dict):
-                print_debug(f'> > {item["type"]}: {item["hash"]}')
+                print_debug(f"> > {item['type']}: {item['hash']}")
 
     if os.path.exists(file_path):  # if file already exists
         existing_checksum = None

--- a/jellybench_py/core.py
+++ b/jellybench_py/core.py
@@ -164,19 +164,19 @@ def obtainSource(
     if downloaded_checksum == source_hash or source_hash is None:  # if valid/no sum
         if args.debug_flag and args.ignore_hash:
             print_debug("> File successfully verified with checksum")
-        return True, file_path  # Checksum 
-    
+        return True, file_path  # Checksum
+
     else:
         if args.debug_flag:
-            print_debug(f"> Checksum failed, downloaded file hash:")
+            print_debug("> Checksum failed, downloaded file hash:")
             print_debug(f"> > sha256: {downloaded_checksum}")
-        
+
         if args.ignore_hash:
-            print_debug(f"> Ignoring invalid checksum")
+            print_debug("> Ignoring invalid checksum")
             return True, file_path
         else:
             if args.debug_flag:
-                print_debug(f"> Expected file hash:")
+                print_debug("> Expected file hash:")
                 print_debug(f"> > sha256: {source_hash}")
             # os.remove(file_path)  # Delete file if checksum doesn't match
             return False, "Invalid Checksum!"  # Checksum invalid

--- a/jellybench_py/core.py
+++ b/jellybench_py/core.py
@@ -109,10 +109,10 @@ def obtainSource(
             return False, "Request error"  # Network issues or invalid URL
 
     if args.debug_flag:
-        print('> Downloading file...')
-        print(f'> > Source URL: {source_url}')
-        print(f'> > Target Path: {target_path}')
-        print('> > Server Provided Hashes:')
+        print("> Downloading file...")
+        print(f"> > Source URL: {source_url}")
+        print(f"> > Target Path: {target_path}")
+        print("> > Server Provided Hashes:")
         for i, j in enumerate(hash_dict):
             print(f'> > > {j["type"]}: {j["hash"]}')
 
@@ -148,8 +148,8 @@ def obtainSource(
     if downloaded_checksum == source_hash or source_hash is None:  # if valid/no sum
         return True, file_path  # Checksum valid
     elif args.debug_flag and args.ignore_hash:
-        print(f'> Checksum failed, expecting: {source_hash}')
-        print(f'> Ignoring invalid checksum of: {downloaded_checksum}')
+        print(f"> Checksum failed, expecting: {source_hash}")
+        print(f"> Ignoring invalid checksum of: {downloaded_checksum}")
         return True, file_path
     else:
         # os.remove(file_path)  # Delete file if checksum doesn't match
@@ -478,7 +478,7 @@ def parse_args():
         "--ignore-hash",
         dest="ignore_hash",
         action="store_true",
-        help="Ignore file hash"
+        help="Ignore file hash",
     )
     return parser.parse_args()
 

--- a/jellybench_py/core.py
+++ b/jellybench_py/core.py
@@ -475,10 +475,10 @@ def parse_args():
     )
 
     parser.add_argument(
-        "--ignore-hash",
+        "--ignorehash",
         dest="ignore_hash",
         action="store_true",
-        help="Ignore file hash",
+        help=argparse.SUPPRESS,
     )
     return parser.parse_args()
 

--- a/jellybench_py/core.py
+++ b/jellybench_py/core.py
@@ -147,6 +147,10 @@ def obtainSource(
     # print(f"CHECKSUM: {downloaded_checksum}")
     if downloaded_checksum == source_hash or source_hash is None:  # if valid/no sum
         return True, file_path  # Checksum valid
+    elif args.debug_flag and args.ignore_hash:
+        print(f'> Checksum failed, expecting: {source_hash}')
+        print(f'> Ignoring invalid checksum of: {downloaded_checksum}')
+        return True, file_path
     else:
         # os.remove(file_path)  # Delete file if checksum doesn't match
         print(f"\nSource hash is {source_hash} but we got {downloaded_checksum}.")
@@ -468,6 +472,13 @@ def parse_args():
         dest="debug_flag",
         action="store_true",
         help="Enable additional debug output",
+    )
+
+    parser.add_argument(
+        "--ignore-hash",
+        dest="ignore_hash",
+        action="store_true",
+        help="Ignore file hash"
     )
     return parser.parse_args()
 

--- a/jellybench_py/core.py
+++ b/jellybench_py/core.py
@@ -109,10 +109,10 @@ def obtainSource(
             return False, "Request error"  # Network issues or invalid URL
 
     if args.debug_flag:
-        print(f'> Downloading file...')
+        print('> Downloading file...')
         print(f'> > Source URL: {source_url}')
         print(f'> > Target Path: {target_path}')
-        print(f'> > Server Provided Hashes:')
+        print('> > Server Provided Hashes:')
         for i, j in enumerate(hash_dict):
             print(f'> > > {j["type"]}: {j["hash"]}')
 

--- a/jellybench_py/core.py
+++ b/jellybench_py/core.py
@@ -30,7 +30,7 @@ import requests
 
 from jellybench_py import api, ffmpeg_log, hwi, worker
 from jellybench_py.constant import Constants, Style
-from jellybench_py.util import confirm, get_nvenc_session_limit, styled
+from jellybench_py.util import confirm, get_nvenc_session_limit, print_debug, styled
 
 
 def obtainSource(
@@ -109,12 +109,12 @@ def obtainSource(
             return False, "Request error"  # Network issues or invalid URL
 
     if args.debug_flag:
-        print("> Downloading file...")
-        print(f"> > Source URL: {source_url}")
-        print(f"> > Target Path: {target_path}")
-        print("> > Server Provided Hashes:")
-        for i, j in enumerate(hash_dict):
-            print(f'> > > {j["type"]}: {j["hash"]}')
+        print_debug("> Downloading file...")
+        print_debug(f"> > Source URL: {source_url}")
+        print_debug(f"> > Target Path: {target_path}")
+        print_debug("> > Server Provided Hashes:")
+        for idx, item in enumerate(hash_dict):
+            print_debug(f'> > > {item["type"]}: {item["hash"]}')
 
     hash_algorithm, source_hash, hash_message = match_hash(hash_dict)
 
@@ -148,8 +148,8 @@ def obtainSource(
     if downloaded_checksum == source_hash or source_hash is None:  # if valid/no sum
         return True, file_path  # Checksum valid
     elif args.debug_flag and args.ignore_hash:
-        print(f"> Checksum failed, expecting: {source_hash}")
-        print(f"> Ignoring invalid checksum of: {downloaded_checksum}")
+        print_debug(f"> Checksum failed, expecting: {source_hash}")
+        print_debug(f"> Ignoring invalid checksum of: {downloaded_checksum}")
         return True, file_path
     else:
         # os.remove(file_path)  # Delete file if checksum doesn't match

--- a/jellybench_py/core.py
+++ b/jellybench_py/core.py
@@ -648,7 +648,7 @@ def cli() -> None:
     # Download ffmpeg
     ffmpeg_data = server_data["ffmpeg"]
     print(styled("Loading ffmpeg", [Style.BOLD]))
-    print('| Searching local "ffmpeg" -', end="")
+    print('| Searching local "ffmpeg"...')
     ffmpeg_download = obtainSource(
         args.ffmpeg_path,
         ffmpeg_data["ffmpeg_source_url"],

--- a/jellybench_py/core.py
+++ b/jellybench_py/core.py
@@ -64,9 +64,6 @@ def obtainSource(
         return sha256_hash.hexdigest()
 
     def download_file(url, file_path, filename):
-        if args.debug_flag:
-            print_debug(f"> > Downloading file: {url}")
-
         label = r'| "{filename}" ({size:.2f}MB)'
         try:
             # Send HTTP request to get the file
@@ -167,14 +164,22 @@ def obtainSource(
     if downloaded_checksum == source_hash or source_hash is None:  # if valid/no sum
         if args.debug_flag and args.ignore_hash:
             print_debug("> File successfully verified with checksum")
-        return True, file_path  # Checksum valid
-    elif args.debug_flag and args.ignore_hash:
-        print_debug(f"> Checksum failed, expecting: {source_hash}")
-        print_debug(f"> Ignoring invalid checksum of: {downloaded_checksum}")
-        return True, file_path
+        return True, file_path  # Checksum 
+    
     else:
-        # os.remove(file_path)  # Delete file if checksum doesn't match
-        return False, "Invalid Checksum!"  # Checksum invalid
+        if args.debug_flag:
+            print_debug(f"> Checksum failed, downloaded file hash:")
+            print_debug(f"> > sha256: {downloaded_checksum}")
+        
+        if args.ignore_hash:
+            print_debug(f"> Ignoring invalid checksum")
+            return True, file_path
+        else:
+            if args.debug_flag:
+                print_debug(f"> Expected file hash:")
+                print_debug(f"> > sha256: {source_hash}")
+            # os.remove(file_path)  # Delete file if checksum doesn't match
+            return False, "Invalid Checksum!"  # Checksum invalid
 
 
 def unpackArchive(archive_path, target_path):

--- a/jellybench_py/core.py
+++ b/jellybench_py/core.py
@@ -108,6 +108,14 @@ def obtainSource(
         except requests.exceptions.RequestException:
             return False, "Request error"  # Network issues or invalid URL
 
+    if args.debug_flag:
+        print(f'> Downloading file...')
+        print(f'> > Source URL: {source_url}')
+        print(f'> > Target Path: {target_path}')
+        print(f'> > Server Provided Hashes:')
+        for i, j in enumerate(hash_dict):
+            print(f'> > > {j["type"]}: {j["hash"]}')
+
     hash_algorithm, source_hash, hash_message = match_hash(hash_dict)
 
     target_path = os.path.realpath(target_path)  # Relative Path!

--- a/jellybench_py/core.py
+++ b/jellybench_py/core.py
@@ -132,14 +132,13 @@ def obtainSource(
             print_debug(f"> > {hash_algorithm}: {existing_checksum}")
 
         if existing_checksum == source_hash or source_hash is None:  # if valid/no sum
-            if (
-                args.debug_flag
-                and existing_checksum == source_hash
-                and args.ignore_hash
-            ):
-                print_debug(
-                    "> Existing file hash matches server provided hash, skipping download."
-                )
+            if args.debug_flag and args.ignore_hash:
+                if source_hash:
+                    print_debug(
+                        "> Existing file hash matches server provided hash, skipping download."
+                    )
+                else:
+                    print_debug("> No Server provided hash, skipping download.")
             print(" success!")
             if not quiet:
                 print(hash_message)

--- a/jellybench_py/core.py
+++ b/jellybench_py/core.py
@@ -520,19 +520,17 @@ def cli() -> None:
     print()
 
     if args.debug_flag:
-        print(
-            styled("Dev Mode", [Style.BG_MAGENTA, Style.WHITE])
-            + ": Special Features and Output enabled  "
-            + styled("DO NOT UPLOAD RESULTS!", [Style.RED])
+        print_debug(
+            ": Special Features and Output enabled",
+            styled("DO NOT UPLOAD RESULTS!", [Style.RED]),
+            prefix="Dev Mode",
         )
         print()
     print(styled("System Initialization", [Style.BOLD]))
 
     if not args.server_url.startswith("http") and args.debug_flag:
         if os.path.exists(args.server_url):
-            print(
-                styled("|", [Style.BG_MAGENTA, Style.WHITE]) + " Using local test-file"
-            )
+            print_debug("Using local test-file")
             platforms = "local"
             platform_id = "local"
         else:
@@ -542,10 +540,9 @@ def cli() -> None:
             exit()
     else:
         if args.server_url != Constants.DEFAULT_SERVER_URL:
-            print(
-                styled("|", [Style.BG_MAGENTA, Style.WHITE])
-                + " Not using official Server!  "
-                + styled("DO NOT UPLOAD RESULTS!", [Style.RED])
+            print_debug(
+                " Not using official Server!",
+                styled("DO NOT UPLOAD RESULTS!", [Style.RED]),
             )
         platforms = api.getPlatform(
             args.server_url
@@ -648,7 +645,7 @@ def cli() -> None:
     # Download ffmpeg
     ffmpeg_data = server_data["ffmpeg"]
     print(styled("Loading ffmpeg", [Style.BOLD]))
-    print('| Searching local "ffmpeg"...',end='')
+    print('| Searching local "ffmpeg"...', end="")
     ffmpeg_download = obtainSource(
         args.ffmpeg_path,
         ffmpeg_data["ffmpeg_source_url"],

--- a/jellybench_py/core.py
+++ b/jellybench_py/core.py
@@ -557,7 +557,7 @@ def cli() -> None:
 
     if not args.server_url.startswith("http") and args.debug_flag:
         if os.path.exists(args.server_url):
-            print_debug("Using local test-file")
+            print_debug(" Using local test-file")
             platforms = "local"
             platform_id = "local"
         else:

--- a/jellybench_py/core.py
+++ b/jellybench_py/core.py
@@ -108,19 +108,19 @@ def obtainSource(
         except requests.exceptions.RequestException:
             return False, "Request error"  # Network issues or invalid URL
 
-    if args.debug_flag:
-        print_debug("> Downloading file...")
-        print_debug(f"> > Source URL: {source_url}")
-        print_debug(f"> > Target Path: {target_path}")
-        print_debug("> > Server Provided Hashes:")
-        for idx, item in enumerate(hash_dict):
-            print_debug(f'> > > {item["type"]}: {item["hash"]}')
-
     hash_algorithm, source_hash, hash_message = match_hash(hash_dict)
 
     target_path = os.path.realpath(target_path)  # Relative Path!
     filename = os.path.basename(source_url)  # Extract filename from the URL
     file_path = os.path.join(target_path, filename)  # path/filename
+
+    if args.debug_flag:
+        print()
+        print_debug(f"> > Source URL: {source_url}")
+        print_debug(f"> > Target File Path: {file_path}")
+        print_debug("> > Server Provided Hashes:")
+        for idx, item in enumerate(hash_dict):
+            print_debug(f'> > > {item["type"]}: {item["hash"]}')
 
     if os.path.exists(file_path):  # if file already exists
         existing_checksum = None
@@ -648,7 +648,7 @@ def cli() -> None:
     # Download ffmpeg
     ffmpeg_data = server_data["ffmpeg"]
     print(styled("Loading ffmpeg", [Style.BOLD]))
-    print('| Searching local "ffmpeg"...')
+    print('| Searching local "ffmpeg"...',end='')
     ffmpeg_download = obtainSource(
         args.ffmpeg_path,
         ffmpeg_data["ffmpeg_source_url"],

--- a/jellybench_py/core.py
+++ b/jellybench_py/core.py
@@ -144,8 +144,11 @@ def obtainSource(
             if not quiet:
                 print(hash_message)
             return True, file_path  # Checksum valid, no need to download again
+        elif args.ignore_hash:
+            print_debug("> Ignoring hash mismatch, using existing file.")
+            return True, file_path
         else:
-            if args.debug_flag and args.ignore_hash:
+            if args.debug_flag:
                 print_debug(
                     "> Existing file hash does not match server provided hash. Downloading new file"
                 )

--- a/jellybench_py/util.py
+++ b/jellybench_py/util.py
@@ -32,5 +32,5 @@ def get_nvenc_session_limit(driver_version: int) -> int:
         return 0
 
 
-def print_debug(string: str, prefix: str | None = "|"):
-    print(styled(prefix, [Style.BG_MAGENTA, Style.WHITE]), string)
+def print_debug(*string: str, prefix: str | None = "|"):
+    print(styled(prefix, [Style.BG_MAGENTA, Style.WHITE]), *string)

--- a/jellybench_py/util.py
+++ b/jellybench_py/util.py
@@ -32,5 +32,5 @@ def get_nvenc_session_limit(driver_version: int) -> int:
         return 0
 
 
-def print_debug(string: str):
-    print(styled("|", [Style.BG_MAGENTA, Style.WHITE]), string)
+def print_debug(string: str, prefix: str | None = "|"):
+    print(styled(prefix, [Style.BG_MAGENTA, Style.WHITE]), string)

--- a/jellybench_py/util.py
+++ b/jellybench_py/util.py
@@ -30,3 +30,7 @@ def get_nvenc_session_limit(driver_version: int) -> int:
         return 3
     else:
         return 0
+
+
+def print_debug(string: str):
+    print(styled("|", [Style.BG_MAGENTA, Style.WHITE]), string)


### PR DESCRIPTION
Add a flag to ignore invalid file hashes.

When both  `--debug` and `--ignore-hash` flags are set, invalid checksums will produce warnings but the test will continue.

