### PR TITLE
minor UI improvements/ cleanup

### DIFF
--- a/jellybench_py/core.py
+++ b/jellybench_py/core.py
@@ -324,11 +324,13 @@ def benchmark(ffmpeg_cmd: str, debug_flag: bool, prog_bar, limit=0) -> tuple:
             "single_worker_speed": max_pass_run_data["speed"],
             "single_worker_rss_kb": max_pass_run_data["rss_kb"],
         }
-        prog_bar.update(status="Done", workers=max_pass, speed=f"{last_speed:.02f}")
+        if prog_bar:
+            prog_bar.update(status="Done", workers=max_pass, speed=f"{last_speed:.02f}")
         return True, runs, result
     else:
-        prog_bar.label = "Skipped | Workers: 00 | Last Speed: 00.00"
-        prog_bar.update(status="Skipped", workers=0, speed=0)
+        if prog_bar:
+            prog_bar.label = "Skipped | Workers: 00 | Last Speed: 00.00"
+            prog_bar.update(status="Skipped", workers=0, speed=0)
         return False, runs, {}
 
 

--- a/jellybench_py/core.py
+++ b/jellybench_py/core.py
@@ -785,14 +785,14 @@ def cli() -> None:
         ffmpeg_log.set_test_header(file["name"])
         if args.debug_flag:
             print()
-            print(f"| Current File: {file['name']}")
+            print_debug(f"Current File: {file['name']}")
         filename = os.path.basename(file["source_url"])
         current_file = os.path.abspath(f"{args.video_path}/{filename}")
         current_file = current_file.replace("\\", "\\\\")
         tests = file["data"]
         for test in tests:
             if args.debug_flag:
-                print(
+                print_debug(
                     f"> > Current Test: {test['from_resolution']} - {test['to_resolution']}"
                 )
             commands = test["arguments"]
@@ -800,7 +800,7 @@ def cli() -> None:
                 test_data = {}
                 if command["type"] in supported_types:
                     if args.debug_flag:
-                        print(f"> > > Current Device: {command['type']}")
+                        print_debug(f"> > > Current Device: {command['type']}")
                     arguments = command["args"]
                     arguments = arguments.format(
                         video_file=current_file,

--- a/jellybench_py/core.py
+++ b/jellybench_py/core.py
@@ -403,7 +403,7 @@ def check_driver_limit(device: dict, ffmpeg_binary: str, gpu_idx: int):
         skip_device = confirm(
             message="| > Do you want to skip GPU tests?", default=False
         )
-        limited_driver = limit
+        limited_driver = successful_count
     else:
         print(" Error!")
         print("| > Your GPU is not capable of running NvEnc Streams!")

--- a/jellybench_py/core.py
+++ b/jellybench_py/core.py
@@ -403,7 +403,9 @@ def check_driver_limit(device: dict, ffmpeg_binary: str, gpu_idx: int):
             f"| > Your GPU driver does only allow {successful_count} concurrent NvEnc sessions!"
         )
         skip_device = confirm(
-            message="| > Do you want to skip GPU tests?", default=False
+            message="| > Do you want to skip GPU tests?",
+            default=False,
+            automate=skip_prompts,
         )
         limited_driver = successful_count
     else:
@@ -436,7 +438,7 @@ def only_do_upload_flow():
     output_file = args.output_path
     filename = os.path.basename(output_file)
     print(f'Uploading "{filename}" to "{args.server_url}"')
-    if not confirm(default=True):
+    if not confirm(default=True, automate=skip_prompts):
         exit()
     print()
     if not os.path.exists(output_file):
@@ -509,6 +511,13 @@ def parse_args():
     )
 
     parser.add_argument(
+        "--confirmall",
+        dest="confirmall",
+        action="store_true",
+        help="Run the script without interactivity! (automatically confirm all prompts)",
+    )
+
+    parser.add_argument(
         "--debug",
         dest="debug_flag",
         action="store_true",
@@ -534,6 +543,8 @@ def cli() -> None:
     print()
     print("Welcome to jellybench_py Cheeseburger Edition 🍔")
     print()
+    global skip_prompts
+    skip_prompts = args.confirmall
 
     if args.only_do_upload:
         only_do_upload_flow()
@@ -555,7 +566,7 @@ def cli() -> None:
         subsequent_indent=indent,
     )
     print(discplaimer_text)
-    if not confirm():
+    if not confirm(automate=skip_prompts):
         exit(1)
 
     print()
@@ -748,7 +759,7 @@ def cli() -> None:
                     test_arg_count += 1
     print(f"We will do {test_arg_count} tests.")
 
-    if not confirm():
+    if not confirm(automate=skip_prompts):
         exit()
 
     benchmark_data = []
@@ -844,7 +855,9 @@ def cli() -> None:
     }
     output_json(result_data, args.output_path, args.server_url)
     if args.output_path:
-        if confirm(message="Upload results to server?", default=True):
+        if confirm(
+            message="Upload results to server?", default=True, automate=skip_prompts
+        ):
             output_json(result_data, None, args.server_url)
 
 

--- a/jellybench_py/util.py
+++ b/jellybench_py/util.py
@@ -7,7 +7,14 @@ def styled(text: str, styles: list[Style]) -> str:
     return f"{style}{text}{Style.RESET.value}"
 
 
-def confirm(message: str = "Continue", default: bool | None = None) -> bool:
+def confirm(
+    message: str = "Continue", default: bool | None = None, automate: bool | None = None
+) -> bool:
+    if automate:
+        if default:
+            return default
+        else:
+            return True
     prompts = {True: "(Y/n)", False: "(y/N)", None: "(y/n)"}
     full_message = f"{message} {prompts[default]}: "
 


### PR DESCRIPTION
### Progressbar in debug mode
- make sure the progressbar only is opened when the debug flag is not set
- only update the progress , when the bar actually exists

### Faulty indents in debug prints
- make sure all debug prints are using `print_debug` (or are indented correctly)

### Driver Limit
- dont trust the limit detected by driver Version (Windows only)
- use the acually tested limit as a start value

### Confirmall
- add an `automate` arg to the `confirm`-method that will choose the default OR return "True"
- add a new arg `--confirmall` that will be filled in every call of the `confirm` method
