### PR TITLE
Unparsable ffmpeg output

### DIFF
--- a/jellybench_py/core.py
+++ b/jellybench_py/core.py
@@ -1018,6 +1018,15 @@ def cli() -> None:
         prog_bar.finish()  # Ensure the progress bar properly finishes if it was used
     print("")
     main_log.info("Ending Benchmark Section now. FFmpeg logs are finished here.")
+    ffmpeg_incomplete_counter = 0
+    for test in benchmark_data:
+        test_failure_reasons = test["results"]["failure_reasons"]
+        if "incomplete_data_return" in test_failure_reasons:
+            ffmpeg_incomplete_counter += 1
+    if ffmpeg_incomplete_counter > 0:
+        print(
+            f"WARNING! {ffmpeg_incomplete_counter} test(s) where not parsable! Please check the logs and report this as a bug!"
+        )
     print("Benchmark Done. Writing file to Output.")
     result_data = {
         "token": server_data["token"],

--- a/jellybench_py/worker.py
+++ b/jellybench_py/worker.py
@@ -109,6 +109,9 @@ def workMan(worker_count: int, ffmpeg_cmd: str, passed_logger: Logger) -> tuple:
         for pid in range(worker_count):
             process_output = raw_worker_data[pid][0]
 
+            workrss = None
+            rtime = None
+
             framelines = []
             rtime = 0.0
             for line in process_output.split("\n"):
@@ -127,14 +130,46 @@ def workMan(worker_count: int, ffmpeg_cmd: str, passed_logger: Logger) -> tuple:
                     timeline = line.split()
                     rtime = float(timeline[3].split("=")[-1].replace("s", ""))  # rtime
 
+            if not (workrss or rtime):
+                ffmpeg_log.error("The ffmpeg process did not include maxrss/rtime")
+                ffmpeg_log.error(
+                    f"Executed command {ffmpeg_cmd} with {worker_count} parallel Workers"
+                )
+                failure_reason = "incomplete_data_return"
+                ffmpeg_log.warning(f"< < Run failed: {failure_reason}")
+                return True, failure_reason
+
             frames = []
             speeds = []
             framerates = 0
             for line in framelines:
                 new_line = line.split()
-                frames.append(int(float(new_line[0].split("=")[-1])))
-                framerates += int(float(new_line[1].split("=")[-1]))
-                speeds.append(float(new_line[6].split("=")[-1].replace("x", "")))
+                # get values:
+                line_frame = new_line[0].split("=")[-1]
+                line_framerate = new_line[1].split("=")[-1]
+                line_speed = new_line[6].split("=")[-1].replace("x", "")
+
+                # try to convert values
+                try:
+                    line_frame = int(float(line_frame))
+                    line_framerate = int(float(line_framerate))
+                    line_speed = float(line_speed)
+                except ValueError:
+                    ffmpeg_log.error(
+                        f'Impossible to parse frame/framerate/speed from ffmpeg: Frame="{line_frame}", FPS="{line_framerate}", Speed="{line_speed}"'
+                    )
+                    ffmpeg_log.error(
+                        f"Executed command {ffmpeg_cmd} with {worker_count} parallel Workers"
+                    )
+                    failure_reason = "incomplete_data_return"
+                    ffmpeg_log.warning(f"< < Run failed: {failure_reason}")
+                    return True, failure_reason
+
+                # continue with values
+                frames.append(line_frame)
+                framerates += line_framerate
+                speeds.append(line_speed)
+
             lineAmmount = len(framelines)
             if lineAmmount == 0:
                 lineAmmount = 1


### PR DESCRIPTION
This is a temporary solution to mark unparsable runs as failed.
This is related to the fact that ffmpeg does not always output the required values.

This implementation not only handles these issues but will also log and warn the user when issues have occured.
That way we can collect more data about this issue!